### PR TITLE
Restore line and column instead of point

### DIFF
--- a/hlint-refactor-mode.el
+++ b/hlint-refactor-mode.el
@@ -34,9 +34,11 @@ exit code."
 (defun call-process-region-preserve-point (start end program &optional args)
   "Send text from START to END to PROGRAM with ARGS preserving the point.
 This uses `call-process-region-checked' internally."
-  (let ((oldpoint (point)))
+  (let ((line (line-number-at-pos))
+        (column (current-column)))
     (call-process-region-checked start end program args)
-    (goto-char oldpoint)))
+    (goto-line line)
+    (move-to-column column)))
 
 ;;;###autoload
 (defun hlint-refactor (&optional args)


### PR DESCRIPTION
The problem is that point basically represents the number of chars. That means that if we apply e.g. the `redundant do` suggestion three characters are deleted (`do`) so we move three chars back. This feels very weird. Saving the column and the line allows us to go back to the same place (assuming it still exists).

Eventually it might be nice to get the position of where the _semantic_ position moved from `apply-refact` but I am not sure if it's worth the trouble to implement that.
