### PR TITLE
Restore position in window after refactoring

### DIFF
--- a/hlint-refactor.el
+++ b/hlint-refactor.el
@@ -56,10 +56,12 @@ exit code."
   "Send text from START to END to PROGRAM with ARGS preserving the point.
 This uses `call-process-region-checked' internally."
   (let ((line (line-number-at-pos))
-        (column (current-column)))
+        (column (current-column))
+        (ws (window-start)))
     (hlint-refactor-call-process-region-checked start end program args)
     (goto-line line)
-    (move-to-column column)))
+    (move-to-column column)
+    (set-window-start (selected-window) ws)))
 
 ;;;###autoload
 (defun hlint-refactor-refactor-buffer (&optional args)


### PR DESCRIPTION
This prevents the slightly annoying effect of having the buffer jump around in the window after applying a refactoring.